### PR TITLE
Limit number of concurrent updateSamples to 8

### DIFF
--- a/lib/vm-agent.js
+++ b/lib/vm-agent.js
@@ -357,6 +357,12 @@ VmAgent.prototype.createQueue = function (uuid) {
  */
 
 VmAgent.prototype.updateSample = function (options, callback) {
+    if (!this._sampleQueue)
+        this._sampleQueue = async.queue(updateSample.bind(this), 8);
+    this._sampleQueue.push(options, callback);
+}
+
+function updateSample(options, callback) {
     var self = this;
     var log = this.log;
     var uuid = options.uuid;


### PR DESCRIPTION
Currently there is no limit to the number of VMs that can be worked on by `updateSample` at once. This means that at initial startup, all VMs on the CN are processed in parallel at once. Since each of these results in a separate call to ZFS, the number of spawned ZFS commands can get very very high on busy CNs with lots of VMs and datasets.

A limit of 8 at once seems to still clear through a backlog of ~200 VMs in a few minutes after startup without causing timeout issues.