### PR TITLE
fix tools/rsync-to

### DIFF
--- a/tools/rsync-to
+++ b/tools/rsync-to
@@ -17,7 +17,8 @@
 set -o errexit
 
 TOP=$(cd $(dirname $0)/../; pwd)
-NODE=$1
+NODE=root@$1
+VM_AGENT_DIR=/opt/smartdc/agents/lib/node_modules/vm-agent
 
 extraOpts=
 if [[ $(uname -s) != "SunOS" ]]; then
@@ -28,7 +29,7 @@ if [[ $(uname -s) != "SunOS" ]]; then
 fi
 
 rsync -av ${TOP}/ \
-    $NODE:/var/tmp/vm-agent/ \
+    $NODE:${VM_AGENT_DIR} \
     $extraOpts \
     --exclude .git/ \
     --exclude /deps/ \
@@ -36,4 +37,9 @@ rsync -av ${TOP}/ \
     --exclude /tools/ \
     --exclude /tmp/
 
-ssh $NODE cp -R /opt/smartdc/agents/lib/node_modules/vm-agent/node_modules/ /var/tmp/vm-agent/
+state=$(ssh ${NODE} svcs -H -o state vm-agent)
+if [[ "$state" == "maintenance" ]]; then
+    ssh ${NODE} svcadm clear vm-agent
+else
+    ssh ${NODE} svcadm restart vm-agent
+fi


### PR DESCRIPTION
Make tools/rsync-to copy files where vm-agent is actually installed
instead of to /var/tmp and require developers to lofs mount that
directory beforehand.

This also seems to be more consistent with other SDC repositories.

/cc @trentm