### PR TITLE
AGENT-990 fix issues when DNI vm is deleted

### DIFF
--- a/lib/vm-agent.js
+++ b/lib/vm-agent.js
@@ -256,7 +256,7 @@ VmAgent.prototype.updateVmapiVm = function updateVmapiVm(vmUuid, callback) {
                                     delete self.knownDniVms[_vmUuid];
                                 },
                                 DNI_PURGE_DELAY
-                            );
+                            ).unref();
                         }
                         loadErr = new Error('deleted VM had do_not_inventory');
                         loadErr.restCode = 'VmNotInventoriable';

--- a/lib/vm-agent.js
+++ b/lib/vm-agent.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 /*
@@ -125,6 +125,13 @@ var vmadm = require('vmadm');
 var VmWatcher = require('./vm-watcher');
 var VMAPI = require('./vmapi-client');
 
+
+// After a DNI VM is deleted, how long to wait before purging our knowledge that
+// it was a DNI VM? (in ms). We need to delay before purging these because we
+// may get multiple delete events from the watcher and if we've already purged
+// from knownDniVms, we'll not know that this one should be ignored.
+var DNI_PURGE_DELAY = 5 * 60 * 1000; // eslint-disable-line
+
 // initial and maximum values to delay between VMAPI retries. (in ms)
 var INITIAL_UPDATE_DELAY = 500;
 var MAX_UPDATE_DELAY = 30000;
@@ -208,6 +215,7 @@ VmAgent.prototype.initializeProperties = function initializeProperties() {
     self.ready = false;
     self.lastSeenVms = {};
     self.lastPutVms = {};
+    self.knownDniVms = {};
 };
 
 VmAgent.prototype.updateVmapiVm = function updateVmapiVm(vmUuid, callback) {
@@ -231,6 +239,52 @@ VmAgent.prototype.updateVmapiVm = function updateVmapiVm(vmUuid, callback) {
             var opts = {log: self.log, uuid: vmUuid, include_dni: true};
             var startLoad = (new Date()).getTime();
 
+            function _handleLoadErr(_vmUuid, err, next) {
+                var loadErr;
+
+                if (err && err.restCode === 'VmNotFound') {
+                    if (self.knownDniVms[_vmUuid]) {
+                        // DNI VM was deleted, we don't send this to VMAPI but
+                        // we do want to purge it from the list after some delay
+                        // in case other delete events are emitted, we still
+                        // need to know that this was DNI.
+                        if (!self.knownDniVms[_vmUuid].timer) {
+                            self.knownDniVms[_vmUuid].timer = setTimeout(
+                                function _purgeDeletedDNI() {
+                                    self.log.debug({vmUuid: _vmUuid},
+                                        'purging DNI knowledge');
+                                    delete self.knownDniVms[_vmUuid];
+                                },
+                                DNI_PURGE_DELAY
+                            );
+                        }
+                        loadErr = new Error('deleted VM had do_not_inventory');
+                        loadErr.restCode = 'VmNotInventoriable';
+                        self.log.warn({vmUuid: _vmUuid},
+                            'ignoring deleted VM with do_not_inventory');
+                        next(loadErr);
+                        return;
+                    }
+
+                    // We need the VM to have been seen either when it was
+                    // created, or when we initially started up. Otherwise, we
+                    // don't have the VM object to post to VMAPI.
+                    assert.ok(self.lastSeenVms.hasOwnProperty(_vmUuid),
+                        'VM ' + _vmUuid + ' not seen before');
+
+                    self.lastSeenVms[_vmUuid].state = 'destroyed';
+                    self.lastSeenVms[_vmUuid].zone_state = 'destroyed';
+                    stash.vmobj = self.lastSeenVms[_vmUuid];
+
+                    next();
+                    return;
+                }
+
+                // Not an err we know how to handle, pass back up the chain
+                next(err);
+                return;
+            }
+
             vmadm.load(opts, function _onVmLoad(err, vmobj) {
                 var doneLoad = (new Date()).getTime();
                 var loadErr;
@@ -250,30 +304,22 @@ VmAgent.prototype.updateVmapiVm = function updateVmapiVm(vmUuid, callback) {
                 self.log.trace({vmUuid: vmUuid, vmobj: vmobj},
                     'vmadm.load results');
 
-                if (err && err.restCode === 'VmNotFound') {
-                    assert.ok(self.lastSeenVms.hasOwnProperty(vmUuid),
-                        'VM ' + vmUuid + ' not seen before');
-
-                    self.lastSeenVms[vmUuid].state = 'destroyed';
-                    self.lastSeenVms[vmUuid].zone_state = 'destroyed';
-                    stash.vmobj = self.lastSeenVms[vmUuid];
-
-                    cb();
-                    return;
-                } else if (err) {
-                    cb(err);
+                if (err) {
+                    _handleLoadErr(vmUuid, err, cb);
                     return;
                 } else if (vmobj.do_not_inventory) {
                     loadErr = new Error('VM has do_not_inventory set');
                     loadErr.restCode = 'VmNotInventoriable';
                     self.log.warn({vmUuid: vmUuid},
                         'ignoring VM with do_not_inventory');
+                    self.knownDniVms[vmUuid] = {};
                     cb(loadErr);
                     return;
                 }
 
-                // no error, so we must have a VM object
+                // no error, so we must have a VM object, and it's not DNI
                 assert.object(vmobj, 'vmobj');
+                delete self.knownDniVms[vmUuid];
 
                 self.lastSeenVms[vmUuid] = vmobj;
                 stash.vmobj = vmobj;
@@ -581,12 +627,20 @@ VmAgent.prototype.initialUpdate = function initialUpdate(callback) {
 
                 // vmobjs is an array of VM objects
                 for (vmIdx = 0; vmIdx < vmobjs.length; vmIdx++) {
-                    stash.vmadmVms.fullVms[vmobjs[vmIdx].uuid]
-                        = vmobjs[vmIdx];
-                    stash.vmadmVms.compareVms[vmobjs[vmIdx].uuid]
-                        = makeComparable(vmobjs[vmIdx], self.comparisonFields,
-                        'vmadm');
+                    if (vmobjs[vmIdx].do_not_inventory) {
+                        // Keep track of the fact that this VM is DNI in case
+                        // it's deleted later.
+                        self.knownDniVms[vmobjs[vmIdx].uuid] = {};
+                    } else {
+                        // not DNI, so include in the list
+                        stash.vmadmVms.fullVms[vmobjs[vmIdx].uuid]
+                            = vmobjs[vmIdx];
+                        stash.vmadmVms
+                            .compareVms[vmobjs[vmIdx].uuid] = makeComparable(
+                                vmobjs[vmIdx], self.comparisonFields, 'vmadm');
+                    }
                 }
+
                 cb();
             });
         }, function _findVmsToUpdate(stash, cb) {
@@ -627,12 +681,7 @@ VmAgent.prototype.initialUpdate = function initialUpdate(callback) {
                 assert.uuid(vmUuid);
 
                 if (stash.vmadmVms.fullVms.hasOwnProperty(vmUuid)) {
-                    // either create or update, either case we just put, unless
-                    // the VM has do_not_inventory set, in which case we don't
-                    // include it with our update.
-                    if (!stash.vmadmVms.fullVms[vmUuid].do_not_inventory) {
-                        vms[vmUuid] = stash.vmadmVms.fullVms[vmUuid];
-                    }
+                    vms[vmUuid] = stash.vmadmVms.fullVms[vmUuid];
                 } else if (stash.vmapiVms.fullVms.hasOwnProperty(vmUuid)) {
                     // VM exists in VMAPI but not locally, so update state
                     vm = stash.vmapiVms.fullVms[vmUuid];

--- a/lib/vm-agent.js
+++ b/lib/vm-agent.js
@@ -73,7 +73,7 @@
  * If there are errors in any part of this, the entire process will be restarted
  * after a delay. This means a fresh lookup from both systems, so we only ever
  * PUT just-looked-up data into VMAPI. The delay between retry attempts will
- * double on each failure, up to some maximum value. (MAX_UPDATE_DELAY)
+ * double on each failure, up to some maximum value. (MAX_UPDATE_DELAY_MS)
  *
  * After startup, most of the work of vm-agent will be processing the queue of
  * events as they come in from the watcher. When an event occurs, the VM's uuid
@@ -100,7 +100,7 @@
  * delay and then that VM's uuid is added back to the queue (only if the uuid
  * is not already queued) and we will re-run this process when it is next loaded
  * from the queue. The delay before re-queueing will double on each failure, up
- * to some maximum value (MAX_UPDATE_DELAY) but the delay will be reset on a
+ * to some maximum value (MAX_UPDATE_DELAY_MS) but the delay will be reset on a
  * sucessful update.
  *
  *
@@ -130,11 +130,11 @@ var VMAPI = require('./vmapi-client');
 // it was a DNI VM? (in ms). We need to delay before purging these because we
 // may get multiple delete events from the watcher and if we've already purged
 // from knownDniVms, we'll not know that this one should be ignored.
-var DNI_PURGE_DELAY = 5 * 60 * 1000; // eslint-disable-line
+var DNI_PURGE_DELAY_MS = 5 * 60 * 1000; // eslint-disable-line
 
 // initial and maximum values to delay between VMAPI retries. (in ms)
-var INITIAL_UPDATE_DELAY = 500;
-var MAX_UPDATE_DELAY = 30000;
+var INITIAL_UPDATE_DELAY_MS = 500;
+var MAX_UPDATE_DELAY_MS = 30000;
 
 
 function VmAgent(options) {
@@ -209,7 +209,7 @@ VmAgent.prototype.initializeProperties = function initializeProperties() {
     }, 1);
 
     // set values to defaults
-    self.updateDelay = INITIAL_UPDATE_DELAY;
+    self.updateDelay = INITIAL_UPDATE_DELAY_MS;
     self.dirtyVms = [];
     self.retryDelays = {};
     self.ready = false;
@@ -255,7 +255,7 @@ VmAgent.prototype.updateVmapiVm = function updateVmapiVm(vmUuid, callback) {
                                         'purging DNI knowledge');
                                     delete self.knownDniVms[_vmUuid];
                                 },
-                                DNI_PURGE_DELAY
+                                DNI_PURGE_DELAY_MS
                             ).unref();
                         }
                         loadErr = new Error('deleted VM had do_not_inventory');
@@ -397,14 +397,14 @@ VmAgent.prototype.scheduleRetryUpdate = function scheduleRetryUpdate(vmUuid) {
     // timer to re-queue the VM. This is always safe since in the worst
     // case we do an extra update with the latest data.
     if (!self.retryDelays[vmUuid]) {
-        self.retryDelays[vmUuid] = {delay: INITIAL_UPDATE_DELAY};
+        self.retryDelays[vmUuid] = {delay: INITIAL_UPDATE_DELAY_MS};
     }
     delay = self.retryDelays[vmUuid].delay;
 
     // Increment for next time.
     self.retryDelays[vmUuid].delay *= 2;
-    if (self.retryDelays[vmUuid].delay > MAX_UPDATE_DELAY) {
-        self.retryDelays[vmUuid].delay = MAX_UPDATE_DELAY;
+    if (self.retryDelays[vmUuid].delay > MAX_UPDATE_DELAY_MS) {
+        self.retryDelays[vmUuid].delay = MAX_UPDATE_DELAY_MS;
     }
 
     self.log.trace('scheduling retry for ' + vmUuid + ' in ' + delay + ' ms');
@@ -760,8 +760,8 @@ VmAgent.prototype.start = function start() {
                             + 'again in ' + self.updateDelay + ' ms');
                         setTimeout(_doInitialUpdate, self.updateDelay);
                         self.updateDelay *= 2;
-                        if (self.updateDelay > MAX_UPDATE_DELAY) {
-                            self.updateDelay = MAX_UPDATE_DELAY;
+                        if (self.updateDelay > MAX_UPDATE_DELAY_MS) {
+                            self.updateDelay = MAX_UPDATE_DELAY_MS;
                         }
                         return;
                     }

--- a/tests/test.VmAgentRealVmadm.js
+++ b/tests/test.VmAgentRealVmadm.js
@@ -898,10 +898,6 @@ test('Real vmadm, fake VMAPI: new DNI VM', function _test(t) {
                     var keys = Object.keys(vmobjs);
 
                     t.ok(true, 'saw PUT /vms: (' + keys.length + ')');
-                    keys.forEach(function _putVmToVmapi(vm) {
-                        // ignore updates from VMs that existed when we started
-                        mocks.Vmapi.putVm(vmobjs[vm]);
-                    });
                     cb();
                 }
             );
@@ -959,14 +955,14 @@ test('Real vmadm, fake VMAPI: new DNI VM', function _test(t) {
         t.end();
     });
 
-    coordinator.on('vmapi.updateVm', function _onVmapiUpdateVm(vmobj, err) {
-        if (!err) {
-            mocks.Vmapi.putVm(vmobj);
-        }
+    coordinator.on('vmapi.updateVm', function _onVmapiUpdateVm(vmobj) {
         updates.push(vmobj);
     });
 
     coordinator.on('vmadm.lookup', function _onVmadmLookup() {
+        // vmadm.lookup is only emitted when the fakeVmadm is used, we're using
+        // the real vmadm so seeing this would mean something's wrong with the
+        // mocking.
         t.fail('should not have seen vmadm.lookup, should have real vmadm');
     });
 });

--- a/tests/test.VmAgentRealVmadm.js
+++ b/tests/test.VmAgentRealVmadm.js
@@ -30,10 +30,10 @@ var VmAgent;
 
 // For tests we can lower the frequency the periodic watcher polls so we finish
 // in more reasonable time.
-var PERIODIC_INTERVAL = 1000;
-var UPDATES_POLL_FREQ = 50; // Freq. to poll the updates array for changes. (ms)
-var WAIT_NON_UPDATE = 30000; // ms, how long to wait before assuming no update
-var WAIT_DNI_DELETE = 5000; // ms, how long to wait for events after deleting
+var PERIODIC_INTERVAL_MS = 1000;
+var UPDATES_POLL_FREQ_MS = 50; // Freq. to poll the updates array for changes
+var WAIT_NON_UPDATE_MS = 30000; // how long to wait before assuming no update
+var WAIT_DNI_DELETE_MS = 5000; // how long to wait for events after deleting
 
 
 /*
@@ -49,7 +49,7 @@ function newConfig() {
     var config = {
         log: mocks.Logger,
         server_uuid: node_uuid.v4(),
-        periodic_interval: PERIODIC_INTERVAL,
+        periodic_interval: PERIODIC_INTERVAL_MS,
         vmapi_url: 'http://127.0.0.1/'
     };
 
@@ -134,16 +134,16 @@ function waitForUpdate(startIdx, params, cb) {
     if (!foundMatch) {
         setTimeout(function _retryWaitForUpdate() {
             waitForUpdate(startIdx, params, cb);
-        }, UPDATES_POLL_FREQ);
+        }, UPDATES_POLL_FREQ_MS);
         return;
     }
 
     cb();
 }
 
-// Wait WAIT_NON_UPDATE ms and ensure there were no updates for VM in that time.
-// It will call cb() after WAIT_NON_UPDATE ms with (err, sawUpdates) where
-// sawUpdates is a count of the number of updates seen for this VM.
+// Wait WAIT_NON_UPDATE_MS ms and ensure there were no updates for VM in that
+// time. It will call cb() after WAIT_NON_UPDATE_MS ms with (err, sawUpdates)
+// where sawUpdates is a count of the number of updates seen for this VM.
 function waitNonUpdate(startIdx, vmUuid, cb) {
     assert.number(startIdx, 'startIdx');
     assert.uuid(vmUuid, 'vmUuid');
@@ -160,7 +160,7 @@ function waitNonUpdate(startIdx, vmUuid, cb) {
         }
 
         cb(null, sawUpdates);
-    }, WAIT_NON_UPDATE);
+    }, WAIT_NON_UPDATE_MS);
 }
 
 function performThenWait(performFn, callback) {
@@ -934,9 +934,9 @@ test('Real vmadm, fake VMAPI: new DNI VM', function _test(t) {
             });
         }, function _waitDestroyVm(arg, cb) {
             setTimeout(function _waitedDestroyVm() {
-                t.ok(true, 'waited ' + WAIT_DNI_DELETE + ' ms after delete');
+                t.ok(true, 'waited ' + WAIT_DNI_DELETE_MS + ' ms after delete');
                 cb();
-            }, WAIT_DNI_DELETE);
+            }, WAIT_DNI_DELETE_MS);
         }, function _checkUpdates(arg, cb) {
             var badUpdates = 0;
 


### PR DESCRIPTION
The problem this fixes is that we have an assert when deleting a VM that ensures it's a VM we've seen before. We want to blow up if that's not the case because something is wrong. We should always have seen a VM when it is deleted, either when we initially started up (where we load all VMs) or when the VM was created.

With do_not_inventory (DNI) we fail here because we ignore the creation of this VM. Then when we notice it is deleted, we no longer can load the VM to see that it has the DNI flag. So the assertion is blown.

To solve this, we will keep track of known DNI VMs as we see (and otherwise ignore) them. This way we will be able to also ignore them on delete.