### PR TITLE
AGENT-995 vm-agent test.FsWatcher.js occasionally hanging on mdata-put test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,10 @@ JSSTYLE_FLAGS =
 
 # Should be the same version as the platform's /usr/node/bin/node.
 NODE_PREBUILT_TAG =	gz
-NODE_PREBUILT_VERSION =	v4.2.3
+NODE_PREBUILT_VERSION =	v0.12.9
 ifeq ($(shell uname -s),SunOS)
-	NODE_PREBUILT_TAG =	gz
 	# Allow building on a SmartOS image other than sdc-smartos/1.6.3.
-	NODE_PREBUILT_IMAGE =	b4bdc598-8939-11e3-bea4-8341f6861379
+	NODE_PREBUILT_IMAGE =	fd2cc906-8938-11e3-beab-4359c665ac99
 endif
 
 # Included definitions

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #
 
 #
-# Copyright (c) 2015, Joyent, Inc.
+# Copyright (c) 2016, Joyent, Inc.
 #
 
 #
@@ -33,11 +33,11 @@ JSSTYLE_FLAGS =
 
 # Should be the same version as the platform's /usr/node/bin/node.
 NODE_PREBUILT_TAG =	gz
-NODE_PREBUILT_VERSION =	v0.10.26
+NODE_PREBUILT_VERSION =	v4.2.3
 ifeq ($(shell uname -s),SunOS)
 	NODE_PREBUILT_TAG =	zone
 	# Allow building on a SmartOS image other than sdc-smartos/1.6.3.
-	NODE_PREBUILT_IMAGE =	fd2cc906-8938-11e3-beab-4359c665ac99
+	NODE_PREBUILT_IMAGE =	b4bdc598-8939-11e3-bea4-8341f6861379
 endif
 
 # Included definitions

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ JSSTYLE_FLAGS =
 NODE_PREBUILT_TAG =	gz
 NODE_PREBUILT_VERSION =	v4.2.3
 ifeq ($(shell uname -s),SunOS)
-	NODE_PREBUILT_TAG =	zone
+	NODE_PREBUILT_TAG =	gz
 	# Allow building on a SmartOS image other than sdc-smartos/1.6.3.
 	NODE_PREBUILT_IMAGE =	b4bdc598-8939-11e3-bea4-8341f6861379
 endif

--- a/lib/vm-watcher.js
+++ b/lib/vm-watcher.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 /*
@@ -87,6 +87,12 @@ var ZoneeventWatcher = require('../lib/watchers/zoneevent-watcher');
 
 
 /*
+ * Globals
+ */
+var MS_PER_SEC = 1000;
+
+
+/*
  * The VmWatcher will emit these events:
  *
  * - VmCreated:   A VM has been created
@@ -146,6 +152,8 @@ util.inherits(VmWatcher, EventEmitter);
  * Returns an array of the names of the properties that were updated in knownVm.
  */
 function updateIfNewer(vmUuid, log, knownVm, updateObj) {
+    var curModified;
+    var newModified;
     var prop;
     var propIdx;
     var props;
@@ -156,30 +164,43 @@ function updateIfNewer(vmUuid, log, knownVm, updateObj) {
     assert.object(knownVm, 'knownVm');
     assert.object(updateObj, 'updateObj');
 
-    /*
-     * Note to the future:
-     *
-     * Unfortunately on node 0.10, we don't have more than a second of
-     * resolution on fs.stat(), so last_modified will always be 000Z. Since
-     * with vm-agent we can have a higher resolution time, when we get 000Z, we
-     * don't know if that's really 000Z or actually 789Z or what. So we err on
-     * the side of caution and treat it as though the update happened at the
-     * *end* of that second instead of the beginning. When we have a newer node
-     * everywhere the .replace() here can be removed and we can just compare the
-     * timestamps.
-     */
-    if (knownVm.last_modified && updateObj.last_modified
-        && (knownVm.last_modified
-            > updateObj.last_modified.replace(/000Z$/, '999Z'))) {
-        // Special case: refuse to update to something with a last_modified
-        // that's older than what we already have.
-        log.warn({
-            currentLastModified: knownVm.last_modified,
-            proposedLastModified: updateObj.last_modified,
-            vm: vmUuid
-        }, 'Refusing to update VM ' + vmUuid + ' to older last_modified');
+    if (knownVm.last_modified && updateObj.last_modified) {
+        curModified = Date.parse(knownVm.last_modified);
+        newModified = Date.parse(updateObj.last_modified);
 
-        return (updated);
+        assert.number(curModified, 'curModified');
+        assert.number(newModified, 'newModified');
+
+        if (newModified % MS_PER_SEC === 0) {
+            /*
+             * Note to the future:
+             *
+             * Unfortunately on node 0.10 that the platform uses, we don't have
+             * more than a second of resolution on fs.stat(), so the
+             * last_modified we get from vmadm will currently always end with
+             * 000Z. Since with vm-agent we can use a newer node that has
+             * milisecond mtime support, when we get 000Z from vmadm, we don't
+             * know if that's really 000Z or actually 789Z or whatever. So we
+             * err on the side of caution and treat it as though the update
+             * happened at the *end* of that second instead of the beginning.
+             * When we have a newer node in all deployed SDC platforms, this
+             * conditional can be removed and we can just compare the
+             * timestamps.
+             */
+            newModified += (MS_PER_SEC - 1); // move to the end of the second.
+        }
+
+        if (curModified > newModified) {
+            // Special case: refuse to update to something with a last_modified
+            // that's older than what we already have.
+            log.warn({
+                currentLastModified: knownVm.last_modified,
+                proposedLastModified: updateObj.last_modified,
+                vm: vmUuid
+            }, 'Refusing to update VM ' + vmUuid + ' to older last_modified');
+
+            return (updated);
+        }
     }
 
     // In case this "create" event has more properties than the previous one, we

--- a/lib/vm-watcher.js
+++ b/lib/vm-watcher.js
@@ -156,8 +156,21 @@ function updateIfNewer(vmUuid, log, knownVm, updateObj) {
     assert.object(knownVm, 'knownVm');
     assert.object(updateObj, 'updateObj');
 
+    /*
+     * Note to the future:
+     *
+     * Unfortunately on node 0.10, we don't have more than a second of
+     * resolution on fs.stat(), so last_modified will always be 000Z. Since
+     * with vm-agent we can have a higher resolution time, when we get 000Z, we
+     * don't know if that's really 000Z or actually 789Z or what. So we err on
+     * the side of caution and treat it as though the update happened at the
+     * *end* of that second instead of the beginning. When we have a newer node
+     * everywhere the .replace() here can be removed and we can just compare the
+     * timestamps.
+     */
     if (knownVm.last_modified && updateObj.last_modified
-        && (knownVm.last_modified > updateObj.last_modified)) {
+        && (knownVm.last_modified
+            > updateObj.last_modified.replace(/000Z$/, '999Z'))) {
         // Special case: refuse to update to something with a last_modified
         // that's older than what we already have.
         log.warn({

--- a/lib/watchers/zoneevent-watcher.js
+++ b/lib/watchers/zoneevent-watcher.js
@@ -116,6 +116,11 @@ ZoneeventWatcher.prototype.start = function start() {
         var line;
         var updateObj;
 
+        if (!self.lstream) {
+            log.trace('cannot read from lstream after stop()');
+            return;
+        }
+
         // read the first line
         line = self.lstream.read();
 
@@ -169,6 +174,8 @@ ZoneeventWatcher.prototype.getPid = function getPid() {
 
 ZoneeventWatcher.prototype.stop = function stop() {
     var self = this;
+
+    self.log.trace('ZoneeventWatcher.stop() called');
 
     self.lstream = null;
 

--- a/tests/test.VmAgentRealVmadm.js
+++ b/tests/test.VmAgentRealVmadm.js
@@ -267,6 +267,7 @@ test('Real vmadm, fake VMAPI', function _test(t) {
             });
         }, function _rebootVm(vmUuid, cb) {
             var opts = {
+                force: true, // force reboot, since soft-reboot is unreliable
                 log: config.log,
                 uuid: payload.uuid
             };


### PR DESCRIPTION
This works around a problem where we have an update that appears to take place in the past because the timestamp on the files we're watching in /zones/&lt;uuid&gt;/config and the vmadm last_modified field both have *second* resolution with node 0.10 on SmartOS. By using node 0.12 we can change this to millisecond resolution for vm-agent, but the platform version will still be using node 0.10 for now, so we need to work around this by treating those last_modified values as happening at the *end* of the second instead of the beginning.