### PR TITLE
fix bug resulting in extra zoneevent children, add test to prevent re…

### DIFF
--- a/lib/vm-agent.js
+++ b/lib/vm-agent.js
@@ -733,6 +733,11 @@ VmAgent.prototype.initialUpdate = function initialUpdate(callback) {
             // On error we're going to get called again so cleanup intermediate
             // state.
             self.dirtyVms = [];
+
+            // Stop the watcher since we failed and will restart it again on
+            // the next loop, but don't wipe out the listeners we setup via
+            // self.setupWatcher() from VmAgent.prototype.start().
+            self.watcher.stop({keepListeners: true});
         }
         callback(err);
     });
@@ -758,6 +763,7 @@ VmAgent.prototype.start = function start() {
                     if (err) {
                         self.log.warn(err, 'initial update failed, will try '
                             + 'again in ' + self.updateDelay + ' ms');
+
                         setTimeout(_doInitialUpdate, self.updateDelay);
                         self.updateDelay *= 2;
                         if (self.updateDelay > MAX_UPDATE_DELAY_MS) {

--- a/lib/vm-watcher.js
+++ b/lib/vm-watcher.js
@@ -363,15 +363,22 @@ VmWatcher.prototype.start = function start() {
     // ... other watchers
 };
 
-VmWatcher.prototype.stop = function stop() {
+VmWatcher.prototype.stop = function stop(opts) {
     var self = this;
+    var keepListeners = false;
+
+    if (opts && opts.keepListeners) {
+        keepListeners = true;
+    }
 
     self.fsWatcher.stop();
     self.periodicWatcher.stop();
     self.zoneeventWatcher.stop();
     // ... other watchers
 
-    self.removeAllListeners();
+    if (!keepListeners) {
+        self.removeAllListeners();
+    }
 };
 
 function uniqueElements() {

--- a/lib/watchers/zoneevent-watcher.js
+++ b/lib/watchers/zoneevent-watcher.js
@@ -49,6 +49,9 @@ function ZoneeventWatcher(opts) {
     self.totalLen = 0;
     self.totalEvents = 0;
 
+    // flag so we know if we should restart on exit or not
+    self.stopped = true;
+
     // Keep a ring buffer with the last RINGBUFFER_SIZE events and a timestamp
     // of when we saw them. (for debugging) You can pull these out of a core
     // with:
@@ -157,12 +160,16 @@ ZoneeventWatcher.prototype.start = function start() {
     self.watcher.stdout.pipe(self.lstream);
     self.watcher.stdin.end();
 
+    self.stopped = false;
+
     self.watcher.on('exit', function _onWatcherExit(code, signal) {
         log.warn({code: code, signal: signal}, 'zoneevent exited');
-        self.stop();
-        process.nextTick(function _restartZoneevent() {
-            self.start();
-        });
+        self.reset();
+        if (!self.stopped) {
+            process.nextTick(function _restartZoneevent() {
+                self.start();
+            });
+        }
     });
 };
 
@@ -172,11 +179,10 @@ ZoneeventWatcher.prototype.getPid = function getPid() {
     return (self.watcher.pid);
 };
 
-ZoneeventWatcher.prototype.stop = function stop() {
+ZoneeventWatcher.prototype.reset = function stop() {
     var self = this;
 
-    self.log.trace('ZoneeventWatcher.stop() called');
-
+    self.log.trace('ZoneeventWatcher.reset() called');
     self.lstream = null;
 
     if (self.watcher) {
@@ -184,6 +190,16 @@ ZoneeventWatcher.prototype.stop = function stop() {
         self.watcher.kill();
         self.watcher = null;
     }
+};
+
+ZoneeventWatcher.prototype.stop = function stop() {
+    var self = this;
+
+    self.log.trace('ZoneeventWatcher.stop() called');
+
+    self.stopped = true;
+
+    self.reset();
 };
 
 ZoneeventWatcher.FIELDS = ['state', 'zone_state'];

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright (c) 2015, Joyent, Inc.
+ * Copyright (c) 2016, Joyent, Inc.
  */
 
 var util = require('util');
@@ -43,7 +43,8 @@ var Logger = {
                 // VM doesn't exist, not really an error
                 return;
             }
-        } else if (err.stderr && err.stderr.match(/^ENOENT, open.*\.xml/)) {
+        } else if (err.stderr && (err.stderr.match(/^ENOENT, open.*\.xml/)
+            || (err.stderr.match(/unable to load \/etc\/zones\/.*.xml/)))) {
             // VM doesn't exist, not really an error
             return;
         }
@@ -247,7 +248,8 @@ function updateServerVms(server_uuid, vmobjs, callback) {
     assert.func(callback, 'callback');
 
     setImmediate(function _emitImmediately() {
-        coordinator.emit('vmapi.updateServerVms', vmobjs, server_uuid);
+        coordinator.emit('vmapi.updateServerVms', vmobjs, server_uuid,
+            (vmapiPutErr ? vmapiPutErr : null));
     });
     if (vmapiPutErr) {
         callback(vmapiPutErr);


### PR DESCRIPTION
…gression

When vm-agent is starting up, if we fail after the _getVmapiVms() in initialUpdate() we end up calling self.watcher.start() again for each failure. One typical case here is when we're failing in the VMAPI PUT /vms for some reason or other. Since we're doing a new .start() on the vm-watcher without stopping the old watcher, we end up spawning new zoneevent processes each time.

Instead, what we should do is stop the existing process on failure and start a new one on the next loop.

This PR adds tests that fail on this bug (it will fail without the fix in lib/vm-agent.js). It also adds a fix for the issue itself and a few changes to the test infrastructure to make this test possible.
